### PR TITLE
Metadata default file name change and environment variable fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,3 @@ RUN cd /build \
 RUN adduser wis2user
 USER wis2user
 WORKDIR /home/wis2user
-RUN groupadd -g 1001 wis2users
-RUN useradd -u 1001 wis2user
-RUN usermod -aG wis2users wis2user

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,6 @@ RUN cd /build \
 RUN adduser wis2user
 USER wis2user
 WORKDIR /home/wis2user
-
-#WORKDIR /
+RUN groupadd -g 1001 wis2users
+RUN useradd -u 1001 wis2user
+RUN usermod -aG wis2users wis2user

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To transform SYNOP data file into BUFR:
 
 ```console
 mkdir output-data
-synop2bufr transform --metadata data/metadata.csv --year 2023 --month 03 --output-dir output-data data/A_SMRO01YRBK211200_C_EDZW_20220321120500_12524785.txt
+synop2bufr transform --metadata data/station_list.csv --year 2023 --month 03 --output-dir output-data data/A_SMRO01YRBK211200_C_EDZW_20220321120500_12524785.txt
 ```
 
 ## Usage Guide

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -25,7 +25,7 @@ Command line interface (CLI)
 .. code-block:: shell
 
    synop2bufr transform \
-       --metadata <station-metadata.csv> \
+       --metadata <station-list.csv> \
        --output-dir <output-directory-path> \
        --year <year-of-observation> \
        --month <month-of-observation> \

--- a/synop2bufr/cli.py
+++ b/synop2bufr/cli.py
@@ -30,7 +30,8 @@ from synop2bufr import __version__, transform as transform_synop
 
 # Configure logger
 LOGGER = logging.getLogger()
-log_level = os.environ.get("LOG_LEVEL")
+# log_level = os.environ.get("LOG_LEVEL")
+log_level = "ERROR"
 logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
     level=getattr(logging, log_level),

--- a/synop2bufr/cli.py
+++ b/synop2bufr/cli.py
@@ -30,8 +30,7 @@ from synop2bufr import __version__, transform as transform_synop
 
 # Configure logger
 LOGGER = logging.getLogger()
-# log_level = os.environ.get("LOG_LEVEL")
-log_level = "ERROR"
+log_level = os.environ.get("LOG_LEVEL", "ERROR")
 logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
     level=getattr(logging, log_level),

--- a/synop2bufr/cli.py
+++ b/synop2bufr/cli.py
@@ -80,7 +80,7 @@ def cli():
 @ click.pass_context
 @ click.argument('synop_file', type=click.File(errors="ignore"))
 @ click.option('--metadata', 'metadata', required=False,
-               default="metadata.csv",
+               default="station_list.csv",
                type=click.File(errors="ignore"),
                help="Name/directory of the station metadata")
 @ click.option('--output-dir', 'output_dir', required=False,


### PR DESCRIPTION
The metadata file by default now takes value `station_list.csv`, and this has been reflected in the docs and readme file.