### PR TITLE
Added encoding of station height and changed default log level to warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ RUN echo "Acquire::Check-Valid-Until \"false\";\nAcquire::Check-Date \"false\";"
     && apt-get update -y \
     && apt-get install -y ${DEBIAN_PACKAGES} \
     && apt-get install -y python3 python3-pip libeccodes-tools \
-    && pip3 install --no-cache-dir https://github.com/wmo-im/csv2bufr/archive/refs/tags/v0.5.1.zip \
-    && pip3 install --no-cache-dir https://github.com/wmo-im/pymetdecoder/archive/refs/tags/v0.1.3.zip
+    && pip3 install --no-cache-dir https://github.com/wmo-im/csv2bufr/archive/refs/tags/v0.6.3.zip \
+    && pip3 install --no-cache-dir https://github.com/wmo-im/pymetdecoder/archive/refs/tags/v0.1.7.zip
 
 ENV LOG_LEVEL=INFO
 

--- a/synop2bufr/__init__.py
+++ b/synop2bufr/__init__.py
@@ -33,7 +33,7 @@ from typing import Iterator, Tuple
 from csv2bufr import BUFRMessage
 from pymetdecoder import synop
 
-__version__ = '0.4.dev1'
+__version__ = '0.4.1'
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1280,6 +1280,7 @@ def transform(data: str, metadata: str, year: int,
             msg['_wsi_local'] = wsi_local
             msg['_latitude'] = latitude
             msg['_longitude'] = longitude
+            msg['_station_height'] = station_height
             conversion_success[tsi] = True
         except Exception:
             conversion_success[tsi] = False

--- a/synop2bufr/cli.py
+++ b/synop2bufr/cli.py
@@ -30,7 +30,7 @@ from synop2bufr import __version__, transform as transform_synop
 
 # Configure logger
 LOGGER = logging.getLogger()
-log_level = os.environ.get("LOG_LEVEL", "ERROR")
+log_level = os.environ.get("LOG_LEVEL", "WARNING")
 logging.basicConfig(
     format="%(asctime)s [%(levelname)s] %(message)s",
     level=getattr(logging, log_level),

--- a/synop2bufr/resources/synop-mappings.json
+++ b/synop2bufr/resources/synop-mappings.json
@@ -31,6 +31,7 @@
         {"eccodes_key": "#1#wigosLocalIdentifierCharacter", "value":"data:_wsi_local"},
         {"eccodes_key": "#1#latitude", "value": "data:_latitude"},
         {"eccodes_key": "#1#longitude", "value": "data:_longitude"},
+        {"eccodes_key": "#1#heightOfStationGroundAboveMeanSeaLevel", "value":"data:_station_height"},
         {"eccodes_key": "#1#blockNumber", "value": "data:block_no"},
         {"eccodes_key": "#1#stationNumber", "value": "data:station_no"},
         {"eccodes_key": "#1#stationOrSiteName", "value": "data:station_id"},

--- a/tests/test_synop2bufr.py
+++ b/tests/test_synop2bufr.py
@@ -134,9 +134,9 @@ def test_bufr(multiple_messages, metadata_string):
     msgs = {}
     for item in result:
         msgs[item['_meta']['id']] = item
-    assert msgs['WIGOS_0-20000-0-15015_20220321T120000']['_meta']['properties']['md5'] == '4adee1b8af9b257653f6fe724bd83744'  # noqa
-    assert msgs['WIGOS_0-20000-0-15020_20220321T120000']['_meta']['properties']['md5'] == '52f2ed9ec19a76f88325159da3c5a850'  # noqa
-    assert msgs['WIGOS_0-20000-0-15090_20220321T120000']['_meta']['properties']['md5'] == '8c0d5d44f1673447530181559d23f2f0'  # noqa
+    assert msgs['WIGOS_0-20000-0-15015_20220321T120000']['_meta']['properties']['md5'] == 'c99408ed63070de0919208b23aacbbd2'  # noqa
+    assert msgs['WIGOS_0-20000-0-15020_20220321T120000']['_meta']['properties']['md5'] == '40a5cc35b454da20c14af88c711d071f'  # noqa
+    assert msgs['WIGOS_0-20000-0-15090_20220321T120000']['_meta']['properties']['md5'] == '86bc25026de14f9f1cba2e449740c0cd'  # noqa
 
 
 def test_invalid_separation():


### PR DESCRIPTION
The following changes have been made:
- Encoding of the station height obtained from the station list metadata file
- Default log level set to warning so the intended messages are displayed for the training exercises.