### PR TITLE
require year and month and do not assume/set a default

### DIFF
--- a/synop2bufr/cli.py
+++ b/synop2bufr/cli.py
@@ -21,8 +21,6 @@
 
 import logging
 import os.path
-# import sys
-from datetime import datetime, timezone
 
 import click
 
@@ -69,30 +67,28 @@ def cli_callbacks(f):
     return f
 
 
-@ click.group()
-@ click.version_option(version=__version__)
+@click.group()
+@click.version_option(version=__version__)
 def cli():
     """synop2bufr"""
     pass
 
 
-@ click.command()
-@ click.pass_context
-@ click.argument('synop_file', type=click.File(errors="ignore"))
-@ click.option('--metadata', 'metadata', required=False,
-               default="station_list.csv",
-               type=click.File(errors="ignore"),
-               help="Name/directory of the station metadata")
-@ click.option('--output-dir', 'output_dir', required=False,
-               default=".",
-               help="Directory for the output BUFR files")
-@ click.option('--year', 'year', required=False,
-               default=datetime.now(timezone.utc).year,
-               help="Year that the data corresponds to")
-@ click.option('--month', 'month', required=False,
-               default=datetime.now(timezone.utc).month,
-               help="Month that the data corresponds to")
-@ cli_option_verbosity
+@click.command()
+@click.pass_context
+@click.argument('synop_file', type=click.File(errors="ignore"))
+@click.option('--metadata', 'metadata', required=False,
+              default="station_list.csv",
+              type=click.File(errors="ignore"),
+              help="Name/directory of the station metadata")
+@click.option('--output-dir', 'output_dir', required=False,
+              default=".",
+              help="Directory for the output BUFR files")
+@click.option('--year', 'year', required=True,
+              help="Year that the data corresponds to")
+@click.option('--month', 'month', required=True,
+              help="Month that the data corresponds to")
+@cli_option_verbosity
 def transform(ctx, synop_file, metadata, output_dir, year, month, verbosity):
 
     try:

--- a/synop2bufr/cli.py
+++ b/synop2bufr/cli.py
@@ -73,7 +73,13 @@ def cli():
     """synop2bufr"""
     pass
 
-  
+
+@click.group()
+def data():
+    """data utilities"""
+    pass
+
+
 @click.command()
 @click.pass_context
 @click.argument('synop_file', type=click.File(errors="ignore"))


### PR DESCRIPTION
As discussed at WIS2 training, setting a default year/month can be dangerous default, so this PR forces the CLI to explicitly pass `--year` and `--month`.  Unused code is also removed as well as fixing click decorators.

cc @maaikelimper 