### PR TITLE
Restructure of return objects

### DIFF
--- a/synop2bufr/__init__.py
+++ b/synop2bufr/__init__.py
@@ -1413,6 +1413,10 @@ def transform(data: str, metadata: str, year: int,
                         "csv": None
                     }
                 }
+                # Reset warning and error messages array for next iteration
+                warning_msgs = []
+                error_msgs = []
+                continue
 
             # Now determine and load the appropriate mappings
             # file depending on the value of the wind indicator.

--- a/synop2bufr/__init__.py
+++ b/synop2bufr/__init__.py
@@ -33,7 +33,7 @@ from typing import Iterator
 from pymetdecoder import synop
 from csv2bufr import BUFRMessage
 
-__version__ = '0.6.dev1'
+__version__ = '0.6.0'
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1332,10 +1332,7 @@ def transform(data: str, metadata: str, year: int,
             yield {
                 "_meta": {
                     "id": None,
-                    "geometry": {
-                        "type": "Point",
-                        "coordinates": None
-                    },
+                    "geometry": None,
                     "properties": {
                         "md5": None,
                         "wigos_station_identifier": None,

--- a/synop2bufr/__init__.py
+++ b/synop2bufr/__init__.py
@@ -33,7 +33,7 @@ from typing import Iterator
 from pymetdecoder import synop
 from csv2bufr import BUFRMessage
 
-__version__ = '0.5.dev2'
+__version__ = '0.6.dev1'
 
 LOGGER = logging.getLogger(__name__)
 
@@ -1329,7 +1329,33 @@ def transform(data: str, metadata: str, year: int,
             LOGGER.error(e)
             error_msgs.append(str(e))
             messages = []  # Fallback to an empty list if no reports extracted
-            yield {'warnings': warning_msgs, 'errors': error_msgs}
+            yield {
+                "_meta": {
+                    "id": None,
+                    "geometry": {
+                        "type": "Point",
+                        "coordinates": None
+                    },
+                    "properties": {
+                        "md5": None,
+                        "wigos_station_identifier": None,
+                        "datetime": None,
+                        "originating_centre": None,
+                        "data_category": None
+                    },
+                    "result": {
+                        "code": FAILED,
+                        "message": "Error encoding, BUFR set to None",
+                        "warnings": warning_msgs,
+                        "errors": error_msgs
+                    },
+                    "template": None,
+                    "csv": None
+                }
+            }
+            # Reset warning and error messages array for next iteration
+            warning_msgs = []
+            error_msgs = []
 
         # Count how many conversions were successful using a dictionary
         conversion_success = {}
@@ -1347,9 +1373,9 @@ def transform(data: str, metadata: str, year: int,
             match = re.match(nil_pattern, message)
             if match:
                 LOGGER.warning(
-                    f"NIL report detected for station {match.group(1)}, no BUFR file created.") # noqa
+                    f"NIL report detected for station {match.group(1)}, no BUFR file created.")  # noqa
                 warning_msgs.append(
-                    f"NIL report detected for station {match.group(1)}, no BUFR file created.") # noqa
+                    f"NIL report detected for station {match.group(1)}, no BUFR file created.")  # noqa
                 continue
 
             # create dictionary to store / return result in
@@ -1366,8 +1392,27 @@ def transform(data: str, metadata: str, year: int,
                 LOGGER.error(
                     f"Error parsing SYNOP report: {message}. {str(e)}!")
                 error_msgs.append(f"Error parsing SYNOP report: {message}. {str(e)}!")  # noqa
-                yield {'warnings': warning_msgs, 'errors': error_msgs}
-                continue
+                yield {
+                    "_meta": {
+                        "id": None,
+                        "geometry": None,
+                        "properties": {
+                            "md5": None,
+                            "wigos_station_identifier": None,
+                            "datetime": None,
+                            "originating_centre": None,
+                            "data_category": None
+                        },
+                        "result": {
+                            "code": FAILED,
+                            "message": "Error encoding, BUFR set to None",
+                            "warnings": warning_msgs,
+                            "errors": error_msgs
+                        },
+                        "template": None,
+                        "csv": None
+                    }
+                }
 
             # Now determine and load the appropriate mappings
             # file depending on the value of the wind indicator.
@@ -1540,8 +1585,8 @@ def transform(data: str, metadata: str, year: int,
 
             # Only convert to BUFR if there's no errors so far
             if conversion_success[tsi]:
-                # now identifier based on WSI and observation
-                # date as identifier
+
+                # Use WSI and observation date as identifier
                 isodate = message.get_datetime().strftime('%Y%m%dT%H%M%S')
 
                 # Write message to CSV object in memory
@@ -1564,7 +1609,9 @@ def transform(data: str, metadata: str, year: int,
 
                 try:
                     result["bufr4"] = message.as_bufr()  # encode to BUFR
-                    status = {"code": PASSED}
+                    status = {"code": PASSED,
+                              "warnings": warning_msgs,
+                              "errors": error_msgs}
 
                 except Exception as e:
                     LOGGER.error("Error encoding BUFR, null returned")
@@ -1574,7 +1621,9 @@ def transform(data: str, metadata: str, year: int,
                     result["bufr4"] = None
                     status = {
                         "code": FAILED,
-                        "message": "Error encoding, BUFR set to None"
+                        "message": "Error encoding, BUFR set to None",
+                        "warnings": warning_msgs,
+                        "errors": error_msgs
                     }
                     conversion_success[tsi] = False
 
@@ -1602,9 +1651,6 @@ def transform(data: str, metadata: str, year: int,
                     "template": bufr_template,
                     "csv": csv_string
                 }
-
-            result["warnings"] = warning_msgs
-            result["errors"] = error_msgs
 
             # now yield result back to caller
             yield result

--- a/tests/test_synop2bufr.py
+++ b/tests/test_synop2bufr.py
@@ -263,7 +263,7 @@ def test_range_qc(metadata_string):
     result = transform(out_of_range, metadata_string, 2000, 1)
 
     for item in result:
-        warning_msgs = item["warnings"]
+        warning_msgs = item["_meta"]["result"]["warnings"]
 
     assert "#1#nonCoordinatePressure: Value (47650.0) out of valid range (50000 - 108000).; Element set to missing" in warning_msgs  # noqa
     assert "#1#airTemperature: Value (334.15) out of valid range (193.15 - 333.15).; Element set to missing" in warning_msgs  # noqa


### PR DESCRIPTION
The return objects now always have the same structue for the `_meta` key, which prevents the bug `Error: '_meta'` when stations can't be found in the metadata or a report can't be parsed. This now means the warning and error messages have been moved to `result["_meta"]["result"]`.