### PR TITLE
Update of mappings to align with new csv2bufr template schema v2

### DIFF
--- a/synop2bufr/resources/synop-mappings-307080.json
+++ b/synop2bufr/resources/synop-mappings-307080.json
@@ -8,7 +8,7 @@
         "editor": "",
         "dateCreated": "2023-09-01",
         "dateModified": "2024-02-05",
-        "id": "c754dbb9-ee5e-4346-8b4b-3b9c1ba43290"
+        "id": "b3abe03b-e502-48c5-a225-133b189207ee"
     },
     "inputShortDelayedDescriptorReplicationFactor": [],
     "inputDelayedDescriptorReplicationFactor": [1,1],

--- a/synop2bufr/resources/synop-mappings-307080.json
+++ b/synop2bufr/resources/synop-mappings-307080.json
@@ -2,7 +2,7 @@
     "conformsTo": "csv2bufr-template-v2.json",
     "metadata": {
         "label": "Surface land stations (manual)",
-        "description": "csv2bufr mapping template for use with synop2bufr and converting FM-12 reports to BUFR, using BUFR sequence 301150, 307080",
+        "description": "csv2bufr mapping template for use with synop2bufr and converting FM-12 reports to BUFR, using BUFR sequence 301150, 307080. This mapping shall be used when the wind variables are estimations.",
         "version": "2",
         "author": "Rory Burke",
         "editor": "",

--- a/synop2bufr/resources/synop-mappings-307080.json
+++ b/synop2bufr/resources/synop-mappings-307080.json
@@ -1,4 +1,15 @@
 {
+    "conformsTo": "csv2bufr-template-v2.json",
+    "metadata": {
+        "label": "Surface land stations (manual)",
+        "description": "Mapping template for converting CSV data from manual land surface stations to BUFR seqeunce 301150, 307080",
+        "version": "2",
+        "author": "Rory Burke",
+        "editor": "",
+        "dateCreated": "2023-09-01",
+        "dateModified": "2024-02-05",
+        "id": "c754dbb9-ee5e-4346-8b4b-3b9c1ba43290"
+    },
     "inputShortDelayedDescriptorReplicationFactor": [],
     "inputDelayedDescriptorReplicationFactor": [1,1],
     "inputExtendedDelayedDescriptorReplicationFactor": [],

--- a/synop2bufr/resources/synop-mappings-307080.json
+++ b/synop2bufr/resources/synop-mappings-307080.json
@@ -2,7 +2,7 @@
     "conformsTo": "csv2bufr-template-v2.json",
     "metadata": {
         "label": "Surface land stations (manual)",
-        "description": "Mapping template for converting CSV data from manual land surface stations to BUFR seqeunce 301150, 307080",
+        "description": "csv2bufr mapping template for use with synop2bufr and converting FM-12 reports to BUFR, using BUFR sequence 301150, 307080",
         "version": "2",
         "author": "Rory Burke",
         "editor": "",

--- a/synop2bufr/resources/synop-mappings-307080.json
+++ b/synop2bufr/resources/synop-mappings-307080.json
@@ -2,7 +2,7 @@
     "conformsTo": "csv2bufr-template-v2.json",
     "metadata": {
         "label": "Surface land stations (manual)",
-        "description": "csv2bufr mapping template for use with synop2bufr and converting FM-12 reports to BUFR, using BUFR sequence 301150, 307080. This mapping shall be used when the wind variables are estimations.",
+        "description": "csv2bufr mapping template for use with synop2bufr and converting FM-12 reports to BUFR, using BUFR sequence 301150, 307080. This mapping is used when the wind variables are estimations.",
         "version": "2",
         "author": "Rory Burke",
         "editor": "",

--- a/synop2bufr/resources/synop-mappings-307096.json
+++ b/synop2bufr/resources/synop-mappings-307096.json
@@ -2,7 +2,7 @@
     "conformsTo": "csv2bufr-template-v2.json",
     "metadata": {
         "label": "Surface land stations (manual)",
-        "description": "Mapping template for converting CSV data from manual land surface stations to BUFR seqeunce 301150, 307096",
+        "description": "csv2bufr mapping template for use with synop2bufr and converting FM-12 reports to BUFR, using BUFR sequence 301150, 307096",
         "version": "2",
         "author": "Rory Burke",
         "editor": "",

--- a/synop2bufr/resources/synop-mappings-307096.json
+++ b/synop2bufr/resources/synop-mappings-307096.json
@@ -2,7 +2,7 @@
     "conformsTo": "csv2bufr-template-v2.json",
     "metadata": {
         "label": "Surface land stations (manual)",
-        "description": "csv2bufr mapping template for use with synop2bufr and converting FM-12 reports to BUFR, using BUFR sequence 301150, 307096. This mapping shall be used when the wind variables are measured with an anemometer.",
+        "description": "csv2bufr mapping template for use with synop2bufr and converting FM-12 reports to BUFR, using BUFR sequence 301150, 307096. This mapping is used when the wind variables are measured with an anemometer.",
         "version": "2",
         "author": "Rory Burke",
         "editor": "",

--- a/synop2bufr/resources/synop-mappings-307096.json
+++ b/synop2bufr/resources/synop-mappings-307096.json
@@ -8,7 +8,7 @@
         "editor": "",
         "dateCreated": "2023-09-01",
         "dateModified": "2024-02-05",
-        "id": "c754dbb9-ee5e-4346-8b4b-3b9c1ba43290"
+        "id": "f7b5e865-fd82-4e93-bdc3-40b705d73860"
     },
     "inputShortDelayedDescriptorReplicationFactor": [],
     "inputDelayedDescriptorReplicationFactor": [1,1],

--- a/synop2bufr/resources/synop-mappings-307096.json
+++ b/synop2bufr/resources/synop-mappings-307096.json
@@ -2,7 +2,7 @@
     "conformsTo": "csv2bufr-template-v2.json",
     "metadata": {
         "label": "Surface land stations (manual)",
-        "description": "csv2bufr mapping template for use with synop2bufr and converting FM-12 reports to BUFR, using BUFR sequence 301150, 307096",
+        "description": "csv2bufr mapping template for use with synop2bufr and converting FM-12 reports to BUFR, using BUFR sequence 301150, 307096. This mapping shall be used when the wind variables are measured with an anemometer.",
         "version": "2",
         "author": "Rory Burke",
         "editor": "",

--- a/synop2bufr/resources/synop-mappings-307096.json
+++ b/synop2bufr/resources/synop-mappings-307096.json
@@ -1,4 +1,15 @@
 {
+    "conformsTo": "csv2bufr-template-v2.json",
+    "metadata": {
+        "label": "Surface land stations (manual)",
+        "description": "Mapping template for converting CSV data from manual land surface stations to BUFR seqeunce 301150, 307096",
+        "version": "2",
+        "author": "Rory Burke",
+        "editor": "",
+        "dateCreated": "2023-09-01",
+        "dateModified": "2024-02-05",
+        "id": "c754dbb9-ee5e-4346-8b4b-3b9c1ba43290"
+    },
     "inputShortDelayedDescriptorReplicationFactor": [],
     "inputDelayedDescriptorReplicationFactor": [1,1],
     "inputExtendedDelayedDescriptorReplicationFactor": [],


### PR DESCRIPTION
As requested, the `conformsTo` and `metadata` sections have been added to the 307080 and 307096 mapping files to align with the new csv2bufr schema.