### PR TITLE
csv2bufr conflict resolution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ if (os.path.exists('MANIFEST')):
     os.unlink('MANIFEST')
 
 # Install dependencies not on PyPI
-subprocess.check_call("pip install 'csv2bufr @ git+https://github.com/wmo-im/csv2bufr.git'", shell=True) # noqa
+subprocess.check_call("pip install https://github.com/wmo-im/csv2bufr/archive/main.zip", shell=True) # noqa
 
 setup(
     name='synop2bufr',


### PR DESCRIPTION
Conflict with csv2bufr version resolved for case where csv2bufr installed independently. 

Note, install from GH via setup.py will need to be removed prior to next release.