### PR TITLE
Exclude stations without tsi from tsi_mapping

### DIFF
--- a/synop2bufr/__init__.py
+++ b/synop2bufr/__init__.py
@@ -1317,7 +1317,8 @@ def transform(data: str, metadata: str, year: int,
                                     f" {tsi} in station list file"))
                     warning_msgs.append(("Duplicate entries found for station"
                                         f" {tsi} in station list file"))
-                tsi_mapping[tsi] = wsi
+                if tsi is not None and tsi != "": 
+                    tsi_mapping[tsi] = wsi
             except Exception as e:
                 LOGGER.error(e)
                 error_msgs.append(str(e))

--- a/synop2bufr/__init__.py
+++ b/synop2bufr/__init__.py
@@ -1317,6 +1317,7 @@ def transform(data: str, metadata: str, year: int,
                                     f" {tsi} in station list file"))
                     warning_msgs.append(("Duplicate entries found for station"
                                         f" {tsi} in station list file"))
+                # only add tsi if not empty
                 if tsi is not None and tsi != "": 
                     tsi_mapping[tsi] = wsi
             except Exception as e:

--- a/synop2bufr/__init__.py
+++ b/synop2bufr/__init__.py
@@ -1318,7 +1318,7 @@ def transform(data: str, metadata: str, year: int,
                     warning_msgs.append(("Duplicate entries found for station"
                                         f" {tsi} in station list file"))
                 # only add tsi if not empty
-                if tsi is not None and tsi != "": 
+                if tsi is not None and tsi != "":
                     tsi_mapping[tsi] = wsi
             except Exception as e:
                 LOGGER.error(e)

--- a/synop2bufr/__init__.py
+++ b/synop2bufr/__init__.py
@@ -146,7 +146,7 @@ def parse_synop(message: str, year: int, month: int) -> dict:
     :returns: `dict` of parsed SYNOP message
     """
     # Make warning messages array global
-    global warning_msgs
+    # global warning_msgs
 
     # Get the full output decoded message from the pymetdecoder package
     try:


### PR DESCRIPTION
While testing, I note that when the station-list contains multiple stations without a tsi, synop2bufr prints a warning:
`/app/wis2box/data/synop2bufr.py:108} WARNING - Duplicate entries found for station  in station list file`

stations without a tsi should not be used in the synop2bufr mapping