### PR TITLE
Protect against none in past weather

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     container:
-      image: wmoim/dim_eccodes_baseimage:noble_eccodes-2.44
+      image: wmoim/dim_eccodes_baseimage:noble_eccodes-2.47
     env:
       BUFR_ORIGINATING_CENTRE: 65535
       BUFR_ORIGINATING_SUBCENTRE: 65535

--- a/synop2bufr/__init__.py
+++ b/synop2bufr/__init__.py
@@ -448,7 +448,10 @@ def parse_synop(message: str, year: int, month: int) -> dict:
     if decoded.get('past_weather') is not None:
         for idx in range(len(decoded.get('past_weather'))):
             fld_name = f'past_weather_{idx+1}'
-            output[fld_name] = decoded['past_weather'][idx]['value']  # noqa
+            if decoded['past_weather'][idx] is None:
+                output[fld_name] = None
+            else:
+                output[fld_name] = decoded['past_weather'][idx]['value']  # noqa
     else:  # Missing values
         output['past_weather_1'] = None
         output['past_weather_2'] = None


### PR DESCRIPTION
This PR adds a protection against none in past weather to prevent the error:
`2026-05-26 07:23:21 [ERROR] Error parsing SYNOP report: AAXX 17181 15480 05997 41901 10114 20089 30035 40052 51009 60002 7000/ 80005 222// 06074 2//// 333 10150 20084 31015 4/000 55300 10188 20000 30000 60007 91004 91106 92427. 'NoneType' object is not subscriptable!`